### PR TITLE
Buttons for downloading and restoring chat histories

### DIFF
--- a/src/components/Chat/ChatInterface.tsx
+++ b/src/components/Chat/ChatInterface.tsx
@@ -225,6 +225,10 @@ export default function ChatInterface() {
     }
 
 
+    /**
+     * Save chat history and related informaiton to a JSON file.
+     * @param filename Filename for the JSON file to be downloaded.
+     */
     const saveHistory = (filename: string) => {
         const data = {
             msgs: rawMsgs,
@@ -235,16 +239,17 @@ export default function ChatInterface() {
         };
 
         const downloadableData = encodeURIComponent(JSON.stringify(data, null, 2));
-        let element: HTMLAnchorElement = document.getElementById('downloadable') as HTMLAnchorElement;
-        if (element === null) {
-            element = document.createElement('a');
-        }
+        const element: HTMLAnchorElement = document.getElementById('save-chat-history') as HTMLAnchorElement;
 
         element.href = `data:application/json;charset=utf-8,${downloadableData}`;
         element.download = filename;
         element.click();
     }
 
+    /**
+     * Restore chat history and related information from a parsed JSON object.
+     * @param data a parsed JSON object that contains chat history and related information.
+     */
     const loadHistory = (data: {
         msgs: Message[],
         questionLevel: string,

--- a/src/components/Chat/ChatInterface.tsx
+++ b/src/components/Chat/ChatInterface.tsx
@@ -245,6 +245,49 @@ export default function ChatInterface() {
         element.click();
     }
 
+    const loadHistory = (data: {
+        msgs: Message[],
+        questionLevel: string,
+        lastQuestion: string,
+        correctSoFar: number,
+        rawQuestionData: any
+    }) => {
+        const msgs: Message[] = data.msgs;
+        const questionLevel: string = data.questionLevel;
+        const lastQuestion: string = data.lastQuestion;
+        const correctSoFar: number = data.correctSoFar;
+        const rawQuestionData = data.rawQuestionData;
+
+        setJustReset(true);
+        setRawMsgs(msgs);
+        setMsgs(msgs.slice(0).reverse().map((msg: Message) => {
+            if (msg.type === 'bot') {
+                return (
+                    <MessageOther
+                        message={msg.message}
+                        timestamp=""
+                        displayName="AI Tutor"
+                        avatarDisp={true}
+                    />
+                );
+            } else {
+                return (
+                    <MessageSelf
+                        message={msg.message}
+                        timestamp=""
+                        displayName="User"
+                        avatarDisp={false}
+                    />
+                );
+            }
+        }));
+
+        setQuestionLevel(questionLevel === 'undefined' ? undefined : questionLevel);
+        setLastQuestion(lastQuestion === 'undefined' ? undefined : lastQuestion);
+        setCorrectSoFar(correctSoFar);
+        setRawQuestionData(rawQuestionData);
+    }
+
 
     return (
         <div className="chatContainer" key="chat-container">
@@ -269,7 +312,7 @@ export default function ChatInterface() {
                 </Paper>
                 {
                     rawQuestionData ?
-                        <TextInput onAddMsg={addMsg} onSaveHistory={saveHistory}/> :
+                        <TextInput onAddMsg={addMsg} onSaveHistory={saveHistory} onLoadHistory={loadHistory} /> :
                         <h3>Initializing the chat. Please wait...</h3>
                 }
             </Paper>

--- a/src/components/Chat/ChatInterface.tsx
+++ b/src/components/Chat/ChatInterface.tsx
@@ -5,7 +5,7 @@ import { TextInput } from "./TextInput";
 import { MessageOther, MessageSelf } from "./Message";
 import { useState } from "react";
 import { ChatRequest, ChatResponseStream, getResponse, Message } from "@site/src/utils";
-import { QuestionRequestStream } from "@site/src/utils/data-model";
+import { QuestionRequestStream, ChatHistory } from "@site/src/utils/data-model";
 import { getQuestion } from "@site/src/utils/chat-utils";
 import { QUESTIONS } from "@site/src/initialQuestions";
 
@@ -250,13 +250,7 @@ export default function ChatInterface() {
      * Restore chat history and related information from a parsed JSON object.
      * @param data a parsed JSON object that contains chat history and related information.
      */
-    const loadHistory = (data: {
-        msgs: Message[],
-        questionLevel: string,
-        lastQuestion: string,
-        correctSoFar: number,
-        rawQuestionData: any
-    }) => {
+    const loadHistory = (data: ChatHistory) => {
         const msgs: Message[] = data.msgs;
         const questionLevel: string = data.questionLevel;
         const lastQuestion: string = data.lastQuestion;

--- a/src/components/Chat/TextInput.tsx
+++ b/src/components/Chat/TextInput.tsx
@@ -84,6 +84,7 @@ export function TextInput({ onAddMsg, onSaveHistory, onLoadHistory }) {
                     >
                         Download
                     </Button>
+                    <a id='save-chat-history' hidden />
                     <Button
                         sx={{ bgcolor: "var(--ifm-color-primary)", color: "white", margin: "5px" }}
                         onClick={() => document.getElementById('load-chat-history')?.click()}

--- a/src/components/Chat/TextInput.tsx
+++ b/src/components/Chat/TextInput.tsx
@@ -5,8 +5,30 @@ import { useState } from 'react';
 import TextEditor from './TextEditor';
 
 
-export function TextInput({ onAddMsg, onSaveHistory }) {
+export function TextInput({ onAddMsg, onSaveHistory, onLoadHistory }) {
     const [value, setValue] = useState("");
+
+    const readJsonFile = (file: Blob) => {
+        return new Promise((resolve, reject) => {
+            const fileReader = new FileReader()
+
+            fileReader.onload = event => {
+                if (event.target) {
+                    resolve(JSON.parse(event.target.result as string))
+                }
+            }
+
+            fileReader.onerror = error => reject(error)
+            fileReader.readAsText(file)
+        });
+    };
+
+    const onFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.target.files) {
+            const parsedData = await readJsonFile(event.target.files[0])
+            onLoadHistory(parsedData);
+        }
+    };
 
     return (
         <>
@@ -64,9 +86,11 @@ export function TextInput({ onAddMsg, onSaveHistory }) {
                     </Button>
                     <Button
                         sx={{ bgcolor: "var(--ifm-color-primary)", color: "white", margin: "5px" }}
+                        onClick={() => document.getElementById('load-chat-history')?.click()}
                     >
                         Upload
                     </Button>
+                    <input id='load-chat-history' type="file" accept=".json,application/json" onChange={onFileUpload} hidden />
                 </div>
             </div>
         </>

--- a/src/components/Chat/TextInput.tsx
+++ b/src/components/Chat/TextInput.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import SendIcon from '@mui/icons-material/Send';
-import { IconButton } from '@mui/material'
+import { Button, IconButton } from '@mui/material'
 import { useState } from 'react';
 import TextEditor from './TextEditor';
 
 
-export function TextInput({ onAddMsg }) {
+export function TextInput({ onAddMsg, onSaveHistory }) {
     const [value, setValue] = useState("");
 
     return (
@@ -55,6 +55,19 @@ export function TextInput({ onAddMsg }) {
                         color: "var(--ifm-color-primary)"
                     }} />
                 </IconButton>
+                <div className="aux-buttons">
+                    <Button
+                        sx={{ bgcolor: "var(--ifm-color-primary)", color: "white", margin: "5px" }}
+                        onClick={() => onSaveHistory('ai-tutor-history.json')}
+                    >
+                        Download
+                    </Button>
+                    <Button
+                        sx={{ bgcolor: "var(--ifm-color-primary)", color: "white", margin: "5px" }}
+                    >
+                        Upload
+                    </Button>
+                </div>
             </div>
         </>
     )

--- a/src/components/Chat/TextInput.tsx
+++ b/src/components/Chat/TextInput.tsx
@@ -3,6 +3,7 @@ import SendIcon from '@mui/icons-material/Send';
 import { Button, IconButton } from '@mui/material'
 import { useState } from 'react';
 import TextEditor from './TextEditor';
+import { ChatHistory } from '@site/src/utils/data-model';
 
 
 export function TextInput({ onAddMsg, onSaveHistory, onLoadHistory }) {
@@ -25,8 +26,13 @@ export function TextInput({ onAddMsg, onSaveHistory, onLoadHistory }) {
 
     const onFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.files) {
-            const parsedData = await readJsonFile(event.target.files[0])
-            onLoadHistory(parsedData);
+            try {
+                const parsedData = (await readJsonFile(event.target.files[0])) as ChatHistory;
+                onLoadHistory(parsedData);
+            } catch (e) {
+                console.error(e);
+                alert('Invalid JSON format. File must be a valid chat history.');
+            }
         }
     };
 

--- a/src/components/Chat/index.css
+++ b/src/components/Chat/index.css
@@ -194,3 +194,10 @@
 .logoutBtn {
     float: right
 }
+
+.aux-buttons {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+}

--- a/src/utils/data-model.ts
+++ b/src/utils/data-model.ts
@@ -40,3 +40,12 @@ export type Message = {
     type: 'user' | 'bot',
     message: string,
 }
+
+
+export type ChatHistory = {
+    msgs: Message[],
+    questionLevel: string,
+    lastQuestion: string,
+    correctSoFar: number,
+    rawQuestionData: any
+}


### PR DESCRIPTION
Added two buttons to the chat interface:
- Download: for downloading the chat history and related state variables (e.g., `lastQuestion`, `correctSoFar`) to a JSON file.
- Upload: for restoring the chat with content from a previously downloaded JSON file.